### PR TITLE
Add adopted texts scraper

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,4 +1,4 @@
-name: Scrape Verbatim Reports
+name: Scrape Adopted Texts
 
 on:
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+*.env
+.cache/
+.DS_Store

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,16 @@
-# Dutch European Parliament Verbatim Report Scraper
+# Dutch European Parliament Adopted Texts Scraper
 
-This repository contains a small scraper that downloads the Dutch verbatim reports of the European Parliament and uploads them as a dataset to the [Hugging Face Hub](https://huggingface.co/).
+This repository contains a simple scraper that downloads the adopted texts ("Aangenomen teksten") of the European Parliament in Dutch and uploads them to the [Hugging Face Hub](https://huggingface.co/).
 
-The scraper starts from the first available report at:
+The scraper starts from the first available adopted text at:
 ```
-https://www.europarl.europa.eu/doceo/document/CRE-4-1996-04-15-TOC_NL.html
+https://www.europarl.europa.eu/doceo/document/TA-5-1999-07-21-TOC_NL.html
 ```
-and follows the "Volgende" links to iterate through the archive. For each page the `-TOC` part is removed to obtain the full report, which is then parsed and cleaned.
+and follows the "Volgende" links to iterate through the archive. For each page the `-TOC` part is removed to obtain the full text, which is then parsed and cleaned.
 
-The dataset is pushed to the public hub repository **vGassen/Dutch-European-Parliament-Verbatim-Reports**. Set the environment variables `HF_USERNAME` and `HF_TOKEN` before running the script so it can authenticate with the hub.
+The dataset is pushed to the public hub repository **vGassen/Dutch-European-Parliament-Adopted-Texts**. Set the environment variables `HF_USERNAME` and `HF_TOKEN` before running the script so it can authenticate with the hub.
 
 ## Usage
-
 ```bash
 pip install -r requirements.txt
 python scraper.py

--- a/scraper.py
+++ b/scraper.py
@@ -9,10 +9,10 @@ from datasets import Dataset
 from huggingface_hub import HfApi, login
 from tqdm import tqdm
 
-# Start from the first available verbatim report page and follow "Volgende" links
-START_TOC_URL = "https://www.europarl.europa.eu/doceo/document/CRE-4-1996-04-15-TOC_NL.html"
+# Start from the first available adopted text page and follow "Volgende" links
+START_TOC_URL = "https://www.europarl.europa.eu/doceo/document/TA-5-1999-07-21-TOC_NL.html"
 HF_USERNAME = os.environ.get("HF_USERNAME", "vGassen")
-HF_DATASET_NAME = "Dutch-European-Parliament-Verbatim-Reports"
+HF_DATASET_NAME = "Dutch-European-Parliament-Adopted-Texts"
 HF_REPO_ID = f"{HF_USERNAME}/{HF_DATASET_NAME}"
 
 
@@ -129,7 +129,7 @@ def scrape() -> list:
             try:
                 text = fetch_report_text(url, session)
                 if text:
-                    data.append({"URL": url, "text": text, "source": "European Parliament Verbatim Report"})
+                    data.append({"URL": url, "text": text, "source": "European Parliament Adopted Text"})
             except Exception as e:
                 print(f"Failed to scrape {url}: {e}")
     return data


### PR DESCRIPTION
## Summary
- scrape adopted texts instead of verbatim reports
- update workflow
- update docs
- add `.gitignore`

## Testing
- `python -m py_compile scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6856ddaf3548832994abc0b7aee7d8bc