### PR TITLE
Improve Dutch text extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml
 datasets
 huggingface_hub
 tqdm
+ftfy


### PR DESCRIPTION
## Summary
- ensure encoding guesses before reading html
- only keep elements that declare `lang=nl`
- clean up any mojibake with ftfy
- update requirements

## Testing
- `python -m pip install -r requirements.txt` *(fails: could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68593c84bdc48329b43cf6f40b032a7b