### PR TITLE
Add Dutch language detection filter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ The scraper starts from the first available report at:
 ```
 https://www.europarl.europa.eu/doceo/document/CRE-4-1996-04-15-TOC_NL.html
 ```
-and follows the "Volgende" links to iterate through the archive. For each page the `-TOC` part is removed to obtain the full report, which is then parsed and cleaned.
+and follows the "Volgende" links to iterate through the archive. For each page the `-TOC` part is removed to obtain the full report, which is then parsed and cleaned. Each extracted paragraph is checked with the `langdetect` library so that only Dutch text is kept.
 
 The dataset is pushed to the public hub repository **vGassen/Dutch-European-Parliament-Verbatim-Reports**. Set the environment variables `HF_USERNAME` and `HF_TOKEN` before running the script so it can authenticate with the hub.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ datasets
 huggingface_hub
 tqdm
 ftfy
+langdetect


### PR DESCRIPTION
## Summary
- filter paragraphs using `langdetect` to ensure Dutch text
- add `langdetect` to requirements
- document language detection step in the README

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*
- `python -m py_compile scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_685a6b97bc7c8329a25b6922f555ef9f